### PR TITLE
Add strategy to always have ordered outbox entries

### DIFF
--- a/src/Outbox/EventsHandler.php
+++ b/src/Outbox/EventsHandler.php
@@ -68,9 +68,13 @@ abstract class EventsHandler
             return;
         }
 
+        $previousEntity = null;
+
         foreach ($outboxEntries as $outboxEntry) {
-            $entity = $this->outboxMappedSuperclass->fromOutboxEntry($outboxEntry);
+            $entity = $this->outboxMappedSuperclass->fromOutboxEntry($outboxEntry, $previousEntity);
             $entityManager->persist($entity);
+
+            $previousEntity = $entity;
         }
 
         $entityManager->getUnitOfWork()->computeChangeSets();

--- a/src/Outbox/OutboxMappedSuperclass.php
+++ b/src/Outbox/OutboxMappedSuperclass.php
@@ -86,8 +86,18 @@ abstract class OutboxMappedSuperclass
      */
     protected $createdAt;
 
-    public function fromOutboxEntry(OutboxEntry $outboxEntry) : OutboxMappedSuperclass
-    {
+    /**
+     * @ORM\Column(type="uuid", nullable=true)
+     * @ORM\OneToOne(targetEntity=OutboxMappedSuperclass::class)
+     *
+     * @var UuidInterface|null
+     */
+    protected $previousEvent;
+
+    public function fromOutboxEntry(
+        OutboxEntry $outboxEntry,
+        ?OutboxMappedSuperclass $previousEntity = null
+    ) : OutboxMappedSuperclass {
         $outbox = clone $this;
 
         $outbox->id            = Uuid::uuid4();
@@ -101,6 +111,15 @@ abstract class OutboxMappedSuperclass
         $outbox->schemaVersion = $outboxEntry->getSchemaVersion();
         $outbox->createdAt     = new DateTimeImmutable();
 
+        if ($previousEntity instanceof OutboxMappedSuperclass) {
+            $outbox->previousEvent = $previousEntity->getId();
+        }
+
         return $outbox;
+    }
+
+    private function getId() : UuidInterface
+    {
+        return $this->id;
     }
 }


### PR DESCRIPTION
To avoid the situation when we can have potentially unordered outbox records, this PR introduces the approach of creating a foreign key constraint on the new `previous_event` column and references the current `id` column (PK). With this association, the database (in our case Postgres) always guarantee the order of insertions due to the relationship (FK) nature.

Examples:
- **First entity**
id: 4c797662-70bf-11e9-a923-1681be663d3e
previous_event: NULL  
- **Second entity**
id: 5fb2cca6-70bf-11e9-a923-1681be663d3e
previous_event: 4c797662-70bf-11e9-a923-1681be663d3e
- **Third entity**
id: 6def3da4-70bf-11e9-a923-1681be663d3e
previous_event: 5fb2cca6-70bf-11e9-a923-1681be663d3e